### PR TITLE
Add lookarounds to keyword matches

### DIFF
--- a/syntaxes/netscaler.tmLanguage
+++ b/syntaxes/netscaler.tmLanguage
@@ -49,19 +49,19 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(add|bind|set|remove|rm|show|sh|unbind|enable|disable|link|unset|show|stat|rename|apply)\b</string>
+			<string>(?<!-|_)(add|bind|set|remove|rm|show|sh|unbind|enable|disable|link|unset|show|stat|rename|apply)(?!-|_\w)</string>
 			<key>name</key>
 			<string>entity.name.function.netscaler</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(stream|feo|appqoe|appflow|transform|tunnel|uiinternal|filter|rise|callhome|aaa|route|responder|rewrite|vpn|interface|ns|audit|system|rsskeytype|lacp|vlan|snmp|ipsec|interfacePair|fis|nd6RAvariables|ssl|server|subscriber|authentication|authorization|lb|serviceGroup|gslb|cmp|L3Param|appfw|ip6TunnelParam|ptp|dns|cache|HA|servicegroup|AppFlow|CH|CF|WL|cs|CR|sslvpn|FR|L3|MBF|Edge|USNIP|PMTUD|rdp|ca|service|locationParameter|tm|LO|channel|LA)\b</string>
+			<string>(?<!-|_)(stream|feo|appqoe|appflow|transform|tunnel|uiinternal|filter|rise|callhome|aaa|route|responder|rewrite|vpn|interface|ns|audit|system|rsskeytype|lacp|vlan|snmp|ipsec|interfacePair|fis|nd6RAvariables|ssl|server|subscriber|authentication|authorization|lb|serviceGroup|gslb|cmp|L3Param|appfw|ip6TunnelParam|ptp|dns|cache|HA|servicegroup|AppFlow|CH|CF|WL|cs|CR|sslvpn|FR|L3|MBF|Edge|USNIP|PMTUD|rdp|ca|service|locationParameter|tm|LO|channel|LA)(?!-|_\w)</string>
 			<key>name</key>
 			<string>entity.name.type.netscaler</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(acl|settings|collector|limitIdentifier|expression|stringmap|partition|ip|ip6|vserver|policy|action|group|user|hostName|alarm|community|parameter|trap|option|tcpProfile|pbr|certkey|cipher|encryptionParams|global|nsRec|addRec|config|feature|mode|profile|radiusAction|view|suffix|zone|sessionParameter|crl|authnProfile|nameServer|weblogparam|selector|eula|httpParam|ptrRec|tcpbufParam|site|certKey|manager|syslogAction|cachegroup|messageaction|node|sessionPolicy|rpcNode|monitor|sessionAction|policylabel|syslogPolicy|trafficPolicy|certPolicy|certAction|trafficAction|portaltheme|clientlessAccessPolicy|param|clientlessAccessProfile|formSSOAction|intranetApplication|cmdPolicy|preauthenticationaction|httpprofile|patset|contentGroup|radiusPolicy|nameserver|diameter|ldapAction|tcpbufparam|tcpParam|serverprofile|preauthenticationpolicy|servicegroup|ldapPolicy|superuser|httpProfile|url|samlAction|samlPolicy|httpCallout|trafficDomain|rnat|inat|pbrs)\b</string>
+			<string>(?<!-|_)(acl|settings|collector|limitIdentifier|expression|stringmap|partition|ip|ip6|vserver|policy|action|group|user|hostName|alarm|community|parameter|trap|option|tcpProfile|pbr|certkey|cipher|encryptionParams|global|nsRec|addRec|config|feature|mode|profile|radiusAction|view|suffix|zone|sessionParameter|crl|authnProfile|nameServer|weblogparam|selector|eula|httpParam|ptrRec|tcpbufParam|site|certKey|manager|syslogAction|cachegroup|messageaction|node|sessionPolicy|rpcNode|monitor|sessionAction|policylabel|syslogPolicy|trafficPolicy|certPolicy|certAction|trafficAction|portaltheme|clientlessAccessPolicy|param|clientlessAccessProfile|formSSOAction|intranetApplication|cmdPolicy|preauthenticationaction|httpprofile|patset|contentGroup|radiusPolicy|nameserver|diameter|ldapAction|tcpbufparam|tcpParam|serverprofile|preauthenticationpolicy|servicegroup|ldapPolicy|superuser|httpProfile|url|samlAction|samlPolicy|httpCallout|trafficDomain|rnat|inat|pbrs)(?!-|_\w)</string>
 			<key>name</key>
 			<string>entity.name.other.netscaler</string>
 		</dict>
@@ -73,7 +73,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(HTTP|SSL|DNS|ANY|TCP|Done|SSL_BRIDGE|NONE|NORMAL|ON|ALLOW|DENY|OFF|Browser|all|default|none|REQUEST|END|NEXT|Optional|NO|YES|DISABLED|ENABLED|Major|Minor|REGEX|TRANSPARENT|RES_OVERRIDE|REQ_OVERRIDE|noop|BASEFILE|Deltajs|debug|info|critical|warning|primary|secondary|RES_DEFAULT|REQ_DEFAULT|replace|replace_all|insert_before_all|insert_before|insert_http_header|nocache|roundrobin|generic|public|nopolicy|DER|ASYMMETRIC|SYMMETRIC|specific|UTF_8|VIP|link-local|NSIP|MIP|SNIP|SECUREONLY|ShareFile_Policy|ShareFile_Action|ShareFile_Profile|_SF_SESSION_ACT|_SF_SESSION_POL|TRUE|FALSE|ns_true|ns_false|NS_TRUE|NS_FALSE)\b</string>
+			<string>(?<!-|_)(HTTP|SSL|DNS|ANY|TCP|Done|SSL_BRIDGE|NONE|NORMAL|ON|ALLOW|DENY|OFF|Browser|all|default|none|REQUEST|END|NEXT|Optional|NO|YES|DISABLED|ENABLED|Major|Minor|REGEX|TRANSPARENT|RES_OVERRIDE|REQ_OVERRIDE|noop|BASEFILE|Deltajs|debug|info|critical|warning|primary|secondary|RES_DEFAULT|REQ_DEFAULT|replace|replace_all|insert_before_all|insert_before|insert_http_header|nocache|roundrobin|generic|public|nopolicy|DER|ASYMMETRIC|SYMMETRIC|specific|UTF_8|VIP|link-local|NSIP|MIP|SNIP|SECUREONLY|ShareFile_Policy|ShareFile_Action|ShareFile_Profile|_SF_SESSION_ACT|_SF_SESSION_POL|TRUE|FALSE|ns_true|ns_false|NS_TRUE|NS_FALSE)(?<!-|_)</string>
 			<key>name</key>
 			<string>keyword.operator.netscaler</string>
 		</dict>


### PR DESCRIPTION
Omit keywords that previously matched in strings containing hyphens or underscores.